### PR TITLE
refactor!: memo_key / id -> call_hash

### DIFF
--- a/python/src/brrr/backends/dynamo.py
+++ b/python/src/brrr/backends/dynamo.py
@@ -37,7 +37,7 @@ class DynamoDbMemStore(Store):
     table_name: str
 
     def key(self, mem_key: MemKey) -> dict:
-        return {"pk": {"S": mem_key.id}, "sk": {"S": mem_key.type}}
+        return {"pk": {"S": mem_key.call_hash}, "sk": {"S": mem_key.type}}
 
     def __init__(self, client: DynamoDBClient, table_name: str):
         self.client = client

--- a/python/src/brrr/backends/in_memory.py
+++ b/python/src/brrr/backends/in_memory.py
@@ -37,7 +37,7 @@ class InMemoryQueue(Queue):
 
 
 def _key2str(key: MemKey) -> str:
-    return f"{key.type}/{key.id}"
+    return f"{key.type}/{key.call_hash}"
 
 
 # Just to drive the point home

--- a/python/src/brrr/call.py
+++ b/python/src/brrr/call.py
@@ -33,10 +33,13 @@ class Call:
     # a task served by Go, from a worker (or other code) in Python, they must
     # both agree on what the input arguments to that call would look like for
     # the environment, and derive the same hash from it.
-    memo_key: str
+    #
+    # The value MUST be a string with only characters in the printable US-ASCII
+    # range.  Obvious candidates are base64 and hexadecimal.
+    call_hash: str
 
     def __eq__(self, other):
-        return isinstance(other, Call) and self.memo_key == other.memo_key
+        return isinstance(other, Call) and self.call_hash == other.call_hash
 
     def __str__(self):
         return f"Call({self.task_name})"

--- a/python/src/brrr/pickle_codec.py
+++ b/python/src/brrr/pickle_codec.py
@@ -36,9 +36,9 @@ class PickleCodec(Codec):
         return h.hexdigest()
 
     def create_call(self, task_name: str, args: tuple, kwargs: dict) -> ArgsKwargsCall:
-        memo_key = self._hash_call(task_name, args, kwargs)
+        call_hash = self._hash_call(task_name, args, kwargs)
         return ArgsKwargsCall(
-            task_name=task_name, args=args, kwargs=kwargs, memo_key=memo_key
+            task_name=task_name, args=args, kwargs=kwargs, call_hash=call_hash
         )
 
     def encode_call(self, call: Call) -> bytes:

--- a/python/tests/test_codec.py
+++ b/python/tests/test_codec.py
@@ -22,7 +22,7 @@ async def test_codec_key_no_args():
     def create_call(task_name, args, kwargs):
         call = old(task_name, args, kwargs)
         bare_call = old(task_name, (), {})
-        return dataclasses.replace(call, memo_key=bare_call.memo_key)
+        return dataclasses.replace(call, call_hash=bare_call.call_hash)
 
     codec.create_call = Mock(side_effect=create_call)
 
@@ -61,7 +61,7 @@ async def test_codec_key_no_args():
 async def test_codec_determinstic():
     call1 = PickleCodec().create_call("foo", (1, 2), dict(b=4, a=3))
     call2 = PickleCodec().create_call("foo", (1, 2), dict(a=3, b=4))
-    assert call1.memo_key == call2.memo_key
+    assert call1.call_hash == call2.call_hash
 
 
 async def test_codec_api():


### PR DESCRIPTION
More explicit about what this is. “id” is too generic and “memo_key” too idiosyncratic.