### PR TITLE
fix(a1-2310): redis resilience queue failover

### DIFF
--- a/python/src/brrr/backends/redis.py
+++ b/python/src/brrr/backends/redis.py
@@ -9,6 +9,8 @@ import bencodepy
 import bencodepy.exceptions
 from redis.exceptions import (
     ConnectionError as RedisConnectionError,
+)
+from redis.exceptions import (
     ResponseError as RedisResponseError,
 )
 

--- a/python/tests/test_redis_queue.py
+++ b/python/tests/test_redis_queue.py
@@ -13,10 +13,10 @@ from brrr.queue import Queue
 from redis.exceptions import (
     ConnectionError as RedisConnectionError,
 )
+from redis.exceptions import DataError
 from redis.exceptions import (
     ResponseError as RedisResponseError,
 )
-from redis.exceptions import DataError
 
 from tests.contract_queue import QueueContract
 


### PR DESCRIPTION
Spurious network issues are causing redis to close connections, killing brrr workers:

- https://app.datadoghq.com/error-tracking/issue/9353d9a4-8d89-11f0-937a-da7ad0900002
- https://app.datadoghq.com/error-tracking/issue/db47b470-4d96-11f0-b361-da7ad0900002

this is a stab at making the redis queue consumption resilient to the two transient failures we’ve observed above:
- dropped connections (ConnectionError). 
- server‑side UNBLOCK during BLPOP (ResponseError) and 

backends/redis.py now now retries ConnectionError and ResponseError within a 60s window; connection pool is force‑disconnected between retries (please review this).

I added a few tests to cover transient recovery, the hard‑cap, decode errors, and a non‑retry case (DataError)

NB: we may want to tune platform’s keepalive settings in workflows_brrr.py (e.g., shorter TCP keepalive idle/interval) to further reduce idle disconnects, but wanted some feedback here