### PR TITLE
feat(py): root_id as context to handlers (app & connection)

### DIFF
--- a/python/src/brrr/__init__.py
+++ b/python/src/brrr/__init__.py
@@ -8,6 +8,9 @@ from .app import (
     AppWorker as AppWorker,
 )
 from .app import (
+    RootId as RootId,
+)
+from .app import (
     Task as Task,
 )
 from .connection import (

--- a/python/src/brrr/app.py
+++ b/python/src/brrr/app.py
@@ -9,7 +9,7 @@ from collections.abc import (
     Sequence,
 )
 from dataclasses import dataclass
-from typing import Any, Concatenate, assert_never, overload
+from typing import Any, Concatenate, Final, NewType, assert_never, overload
 
 from brrr.store import NotFoundError
 
@@ -17,6 +17,8 @@ from .codec import Codec
 from .connection import Connection, Defer, DeferredCall, Request, Response
 
 type Task[C, **P, R] = Callable[Concatenate[C, P], Awaitable[R]]
+
+RootId = NewType("RootId", str)
 
 
 @dataclass
@@ -106,7 +108,7 @@ class AppWorker[C](AppConsumer[C]):
             resp = await self._registry.codec.invoke_task(
                 request.call,
                 handler,
-                ActiveWorker(conn, self._registry),
+                ActiveWorker(conn, self._registry, RootId(request.root_id)),
             )
         except Defer as e:
             return e
@@ -116,10 +118,15 @@ class AppWorker[C](AppConsumer[C]):
 class ActiveWorker[C]:
     _connection: Connection
     _registry: Registry[C]
+    # Exposed only for reference sake of the handler of a call; changing this
+    # value has no effect on how this class behaves.  This class’ implementation
+    # does not read nor care about this value.
+    root_id: Final[RootId]
 
-    def __init__(self, conn: Connection, registry: Registry[C]):
+    def __init__(self, conn: Connection, registry: Registry[C], root_id: RootId):
         self._connection = conn
         self._registry = registry
+        self.root_id = root_id
 
     @overload
     def call[**P, R](

--- a/python/src/brrr/connection.py
+++ b/python/src/brrr/connection.py
@@ -52,6 +52,10 @@ class Defer(Exception):
 class Request:
     # The actual semantically meaningful part of the call
     call: Call
+    # An opaque string which uniquely identifies this particular top-level brrr
+    # schedule operation.  Every “schedule” gets a new root id, regardless of
+    # the call parameters, regardless of cache availability.
+    root_id: str
     # Probably some extra useful out-of-band metadata at some point?  Something
     # like "headers"?  Metadata?  For now we only have calls in a request, but
     # it’s very likely we’ll want to add things here very soon and this is part
@@ -251,7 +255,7 @@ class Server(Connection):
         logger.debug(
             f"Calling {my_topic} -> {msg.root_id}/{msg.call_hash} -> {call.task_name}"
         )
-        req = Request(call=call)
+        req = Request(call=call, root_id=msg.root_id)
         ret = await handler(req, self)
         if isinstance(ret, Defer):
             logger.debug(f"Deferring {msg.root_id}/{msg.call_hash}: {call.task_name}")

--- a/python/tests/test_app.py
+++ b/python/tests/test_app.py
@@ -643,3 +643,22 @@ async def test_custom_context(topic: str) -> None:
         await conn.loop(topic, app.handle)
         assert await app.read(foo)() == "foo"
         assert await app.read(bar)() == "bar"
+
+
+async def test_app_root_id(topic: str) -> None:
+    store = InMemoryByteStore()
+    queue = CloseOnEmptyQueue([topic])
+
+    async def foo(app: TestContext) -> str:
+        return app.root_id
+
+    async with brrr.serve(queue, store, store) as conn:
+        app = AppWorker[TestContext](
+            handlers=dict(foo=foo),
+            codec=DemoPickleCodec(),
+            connection=conn,
+        )
+        await app.schedule(foo, topic=topic)()
+        await conn.loop(topic, app.handle)
+        # Ensure that it exists at all
+        assert await app.read(foo)()

--- a/python/tests/test_connection.py
+++ b/python/tests/test_connection.py
@@ -73,6 +73,20 @@ async def test_conn_exception() -> None:
         assert count == 2
 
 
+async def test_conn_root_id() -> None:
+    store = InMemoryByteStore()
+    queue = CloseOnEmptyQueue([TOPIC])
+
+    async def handler(request: Request, conn: Connection) -> Defer | Response:
+        return Response(payload=request.root_id.encode("utf-8"))
+
+    async with brrr.serve(queue, store, store) as conn:
+        await conn.schedule_raw(TOPIC, "hash1", "foo", b"123")
+        await conn.loop(TOPIC, handler)
+        # Just ensure that it exists at all
+        assert await conn.read_raw("hash1")
+
+
 async def test_conn_nop_closed_queue() -> None:
     store = InMemoryByteStore()
     queue = CloseOnEmptyQueue([TOPIC])


### PR DESCRIPTION
Make root ID of a call graph available in the context passed to handlers of both the connection and the app layer. Extra field, no backwards incompatible changes to sdk, no changes to protocol.