### PR TITLE
fix(py): simpler, more robust in mem queues

### DIFF
--- a/python/src/brrr/backends/in_memory.py
+++ b/python/src/brrr/backends/in_memory.py
@@ -7,55 +7,65 @@ from typing import override
 
 from brrr.store import CompareMismatch, NotFoundError
 
-from ..queue import Message, Queue, QueueInfo, QueueIsClosed, QueueIsEmpty
+from ..queue import Message, Queue, QueueInfo, QueueIsClosed
 from ..store import Cache, MemKey, Store
 
 
-class InMemoryQueue(Queue):
-    """In-memory, inherently ephemeral message queue for testing."""
+class CloseOnEmptyQueue(Queue):
+    """In-memory queue (for testing) which closes when it's empty.
+
+    Closure happens when there is a `get` operation and the queue is empty.
+    Doing a get on a queue with only one item will return that item, leave the
+    queue empty, but not close it yet.  If the next operation is a put, it is
+    accepted, and nothing is closed.
+
+    Closure of one topic affects all topics.  Existing messages on other topics
+    remain available for reading.
+
+    Good fit for deterministic, single threaded tests.  Poor fit for tests
+    involving multiple concurrent consumers.
+
+    >>> q = CloseOnEmptyQueue(["t1", "t2"])
+    >>> asyncio.run(q.put_message("t1", "foo"))
+    >>> asyncio.run(q.put_message("t2", "bar"))
+    >>> asyncio.run(q.get_message("t1"))
+    Message(body='foo')
+    >>> asyncio.run(q.get_message("t1"))
+    Traceback (most recent call last):
+        ...
+    brrr.queue.QueueIsClosed
+    >>> asyncio.run(q.put_message("t1", "frob"))
+    Traceback (most recent call last):
+        ...
+    asyncio.queues.QueueShutDown
+    >>> asyncio.run(q.put_message("t2", "brap"))
+    Traceback (most recent call last):
+        ...
+    asyncio.queues.QueueShutDown
+    >>> asyncio.run(q.get_message("t2"))
+    Message(body='bar')
+    >>> asyncio.run(q.get_message("t2"))
+    Traceback (most recent call last):
+        ...
+    brrr.queue.QueueIsClosed
+
+    """
 
     _queues: Mapping[str, asyncio.Queue[str]]
 
     def __init__(self, topics: Sequence[str]):
-        self._closing = False
-        self._flushing = False
         # Could be updated to allow dynamically creating topics on-demand but
         # this is probably a bit nicer for now.
         self._queues = {k: asyncio.Queue() for k in topics}
 
-    async def close(self) -> None:
-        """Only works in Python ≥3.13"""
-        if self._closing:
-            raise ValueError("InMemoryQueue already closed/closing")
-        self._closing = True
-        for q in self._queues.values():
-            q.shutdown()
-
-    async def join(self) -> None:
-        """Wait for all queues to be fully closed"""
-        await asyncio.gather(*(q.join() for q in self._queues.values()))
-
     @typing.override
     async def get_message(self, topic: str) -> Message:
-        if topic not in self._queues:
-            raise ValueError("invalid topic name")
-
         q = self._queues[topic]
         try:
-            if self._flushing:
-                try:
-                    payload = q.get_nowait()
-                except asyncio.QueueEmpty:
-                    # Backwards compatible with python 3.12
-                    if hasattr(q, "shutdown"):
-                        q.shutdown()
-                    raise QueueIsClosed()
-            else:
-                try:
-                    async with asyncio.timeout(self.recv_block_secs):
-                        payload = await q.get()
-                except TimeoutError:
-                    raise QueueIsEmpty()
+            payload = q.get_nowait()
+        except asyncio.QueueEmpty:
+            self._shutdown()
+            raise QueueIsClosed()
         except asyncio.QueueShutDown:
             raise QueueIsClosed()
 
@@ -64,27 +74,72 @@ class InMemoryQueue(Queue):
 
     @typing.override
     async def put_message(self, topic: str, body: str) -> None:
-        if topic not in self._queues:
-            raise ValueError(f"Unknown topic {topic}")
         await self._queues[topic].put(body)
+
+    def _shutdown(self) -> None:
+        for q in self._queues.values():
+            q.shutdown()
 
     async def get_info(self, topic: str) -> QueueInfo:
         return QueueInfo(num_messages=self._queues[topic].qsize())
 
-    def flush(self) -> None:
-        """Once the queue is empty, automatically close it.
 
-        Use this for testing: schedule all your test jobs, call .flush(), and
-        the jobs themselves will be allowed to fully run to completion, still
-        using the queue and scheduling new messages, until all activity has
-        stopped.
+class CloseOnSilenceQueue(Queue):
+    """In-memory queue (for testing) which closes when it's unused for 1 second.
 
-        This does not work with parallel consumers because one consumer can be
-        working on a job while another one does a .get, sees the queue is empty,
-        and closes it.
+    Activity on any topic is considered activity for all topics.  Closure
+    happens when no message is put on the channel for at least 1 second.  Any
+    pending gets are resolved with a QueueIsClosed exception.  Same for any
+    subsequent gets, to any topic.  Pending messages are still allowed to be
+    retrieved.  No new messages can be put.
 
-        """
-        self._flushing = True
+    Good fit for unit tests involving parallel, synthetic workers which will
+    definitely take <1 second.  Poor fit for tests involving long running tasks.
+    For tests involving only a single consumer, prefer the (deterministic)
+    CloseOnEmptyQueue.
+
+    """
+
+    _queues: Mapping[str, asyncio.Queue[str]]
+    _watchdog: asyncio.Handle | None
+
+    def __init__(self, topics: Sequence[str]):
+        self._queues = {k: asyncio.Queue() for k in topics}
+        self._watchdog = None
+
+    def _kick_watchdog(self) -> None:
+        if self._watchdog is not None:
+            self._watchdog.cancel()
+        self._start_watchdog()
+
+    def _start_watchdog(self) -> None:
+        self._watchdog = asyncio.get_running_loop().call_later(1, self._shutdown)
+
+    @typing.override
+    async def get_message(self, topic: str) -> Message:
+        if self._watchdog is None:
+            self._start_watchdog()
+
+        q = self._queues[topic]
+        try:
+            payload = await q.get()
+        except asyncio.QueueShutDown:
+            raise QueueIsClosed()
+
+        q.task_done()
+        return Message(body=payload)
+
+    @typing.override
+    async def put_message(self, topic: str, body: str) -> None:
+        self._kick_watchdog()
+        await self._queues[topic].put(body)
+
+    def _shutdown(self) -> None:
+        for q in self._queues.values():
+            q.shutdown()
+
+    async def get_info(self, topic: str) -> QueueInfo:
+        return QueueInfo(num_messages=self._queues[topic].qsize())
 
 
 def _key2str(key: MemKey) -> str:

--- a/python/src/brrr/local_app.py
+++ b/python/src/brrr/local_app.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from typing import Any, Awaitable, Callable
 
 from .app import AppWorker, Task
-from .backends.in_memory import InMemoryByteStore, InMemoryQueue
+from .backends.in_memory import CloseOnEmptyQueue, InMemoryByteStore
 from .codec import Codec
 from .connection import Server, serve
 
@@ -15,7 +15,7 @@ class LocalApp[C]:
     """
 
     def __init__(
-        self, *, topic: str, conn: Server, queue: InMemoryQueue, app: AppWorker[C]
+        self, *, topic: str, conn: Server, queue: CloseOnEmptyQueue, app: AppWorker[C]
     ) -> None:
         self._conn = conn
         self._app = app
@@ -29,7 +29,6 @@ class LocalApp[C]:
         if self._has_run:
             raise ValueError("LocalApp has already run")
         self._has_run = True
-        self._queue.flush()
         await self._conn.loop(self._topic, self._app.handle)
 
 
@@ -41,7 +40,7 @@ async def local_app[C](
     Helper function for unit tests which use brrr
     """
     store = InMemoryByteStore()
-    queue = InMemoryQueue([topic])
+    queue = CloseOnEmptyQueue([topic])
 
     async with serve(queue, store, store) as conn:
         app = AppWorker(handlers=handlers, codec=codec, connection=conn)

--- a/python/tests/test_app.py
+++ b/python/tests/test_app.py
@@ -17,7 +17,11 @@ from brrr import (
     Response,
     Task,
 )
-from brrr.backends.in_memory import InMemoryByteStore, InMemoryQueue
+from brrr.backends.in_memory import (
+    CloseOnEmptyQueue,
+    CloseOnSilenceQueue,
+    InMemoryByteStore,
+)
 from brrr.call import Call
 from brrr.codec import Codec
 from brrr.demo_pickle_codec import DemoPickleCodec, DemoPickleCodecContext
@@ -30,7 +34,7 @@ type TestContext = DemoPickleCodecContext
 
 async def test_app_worker(topic: str, task_name: str) -> None:
     store = InMemoryByteStore()
-    queue = InMemoryQueue([topic])
+    queue = CloseOnEmptyQueue([topic])
 
     name_foo, name_bar = names(task_name, ("foo", "bar"))
 
@@ -48,7 +52,6 @@ async def test_app_worker(topic: str, task_name: str) -> None:
             connection=conn,
         )
         await app.schedule(foo, topic=topic)(122)
-        queue.flush()
         await conn.loop(topic, app.handle)
         assert await app.read(foo)(122) == 457
         assert await app.read(name_foo)(122) == 457
@@ -58,7 +61,7 @@ async def test_app_worker(topic: str, task_name: str) -> None:
 
 async def test_app_consumer(topic: str, task_name: str) -> None:
     store = InMemoryByteStore()
-    queue = InMemoryQueue([topic])
+    queue = CloseOnEmptyQueue([topic])
 
     async def foo(app: TestContext, a: int) -> int:
         return a * a
@@ -69,7 +72,6 @@ async def test_app_consumer(topic: str, task_name: str) -> None:
             handlers={task_name: foo}, codec=DemoPickleCodec(), connection=conn
         )
         await appw.schedule(foo, topic=topic)(5)
-        queue.flush()
         await conn.loop(topic, appw.handle)
 
     # Now test that a read-only app can read that
@@ -189,7 +191,7 @@ async def test_asyncio_gather(topic: str, task_name: str) -> None:
 async def test_topics_separate_app_same_conn(topic: str, task_name: str) -> None:
     store = InMemoryByteStore()
     t1, t2 = names(topic, ("1", "2"))
-    queue = InMemoryQueue([t1, t2])
+    queue = CloseOnSilenceQueue([t1, t2])
     name_one, name_two = names(task_name, ("one", "two"))
 
     async def one(app: TestContext, a: int) -> int:
@@ -198,7 +200,6 @@ async def test_topics_separate_app_same_conn(topic: str, task_name: str) -> None
     async def two(app: TestContext, a: int) -> None:
         result = await app.call(name_one, topic=t1)(a + 3)
         assert result == 15
-        await queue.close()
 
     async with brrr.serve(queue, store, store) as conn:
         app1 = AppWorker(
@@ -210,13 +211,11 @@ async def test_topics_separate_app_same_conn(topic: str, task_name: str) -> None
         await app2.schedule(name_two, topic=t2)(7)
         await asyncio.gather(conn.loop(t1, app1.handle), conn.loop(t2, app2.handle))
 
-    await queue.join()
-
 
 async def test_topics_separate_app_separate_conn(topic: str, task_name: str) -> None:
     store = InMemoryByteStore()
     t1, t2 = names(topic, ("1", "2"))
-    queue = InMemoryQueue([t1, t2])
+    queue = CloseOnSilenceQueue([t1, t2])
     name_one, name_two = names(task_name, ("one", "two"))
 
     async def one(app: TestContext, a: int) -> int:
@@ -225,7 +224,6 @@ async def test_topics_separate_app_separate_conn(topic: str, task_name: str) -> 
     async def two(app: TestContext, a: int) -> None:
         result = await app.call(name_one, topic=t1)(a + 3)
         assert result == 15
-        await queue.close()
 
     async with brrr.serve(queue, store, store) as conn1:
         async with brrr.serve(queue, store, store) as conn2:
@@ -240,13 +238,11 @@ async def test_topics_separate_app_separate_conn(topic: str, task_name: str) -> 
                 conn1.loop(t1, app1.handle), conn2.loop(t2, app2.handle)
             )
 
-    await queue.join()
-
 
 async def test_topics_same_app(topic: str, task_name: str) -> None:
     store = InMemoryByteStore()
     t1, t2 = names(topic, ("1", "2"))
-    queue = InMemoryQueue([t1, t2])
+    queue = CloseOnSilenceQueue([t1, t2])
     name_one, name_two = names(task_name, ("one", "two"))
 
     async def one(app: TestContext, a: int) -> int:
@@ -256,7 +252,6 @@ async def test_topics_same_app(topic: str, task_name: str) -> None:
         # N.B.: b2 can use its own brrr instance
         result = await app.call(name_one, topic=t1)(a + 3)
         assert result == 15
-        await queue.close()
 
     async with brrr.serve(queue, store, store) as conn:
         app = AppWorker(
@@ -268,15 +263,12 @@ async def test_topics_same_app(topic: str, task_name: str) -> None:
         # Listen on different topics with the same worker.
         await asyncio.gather(conn.loop(t1, app.handle), conn.loop(t2, app.handle))
 
-    await queue.join()
-
 
 async def test_weird_names(topic: str, task_name: str) -> None:
     store = InMemoryByteStore()
-    queue = InMemoryQueue([topic])
+    queue = CloseOnEmptyQueue([topic])
 
     async def double(app: TestContext, x: int) -> int:
-        await queue.close()
         return x + x
 
     async with brrr.serve(queue, store, store) as conn:
@@ -284,15 +276,13 @@ async def test_weird_names(topic: str, task_name: str) -> None:
             handlers={task_name: double}, codec=DemoPickleCodec(), connection=conn
         )
         await app.schedule(task_name, topic=topic)(7)
-        queue.flush()
         await conn.loop(topic, app.handle)
         assert await app.read(task_name)(7) == 14
 
 
 async def test_app_nop_closed_queue(topic: str) -> None:
     store = InMemoryByteStore()
-    queue = InMemoryQueue([topic])
-    await queue.close()
+    queue = CloseOnEmptyQueue([topic])
     async with brrr.serve(queue, store, store) as conn:
         app = AppWorker(handlers={}, codec=DemoPickleCodec(), connection=conn)
         await conn.loop(topic, app.handle)
@@ -305,7 +295,7 @@ async def test_stop_when_empty(topic: str, task_name: str) -> None:
     calls_pre = Counter[int]()
     calls_post = Counter[int]()
     store = InMemoryByteStore()
-    queue = InMemoryQueue([topic])
+    queue = CloseOnEmptyQueue([topic])
 
     async def foo(app: TestContext, a: int) -> int:
         calls_pre[a] += 1
@@ -320,9 +310,7 @@ async def test_stop_when_empty(topic: str, task_name: str) -> None:
             handlers={task_name: foo}, codec=DemoPickleCodec(), connection=conn
         )
         await app.schedule(foo, topic=topic)(3)
-        queue.flush()
         await conn.loop(topic, app.handle)
-        await queue.join()
 
     assert calls_pre == Counter({0: 1, 1: 2, 2: 2, 3: 2})
     assert calls_post == Counter({1: 1, 2: 1, 3: 1})
@@ -331,13 +319,11 @@ async def test_stop_when_empty(topic: str, task_name: str) -> None:
 @pytest.mark.parametrize("use_gather", [(False,), (True,)])
 async def test_parallel(topic: str, task_name: str, use_gather: bool) -> None:
     store = InMemoryByteStore()
-    queue = InMemoryQueue([topic])
+    queue = CloseOnSilenceQueue([topic])
     name_top, name_block = names(task_name, ("top", "block"))
 
     parallel = 5
     barrier: asyncio.Barrier | None = asyncio.Barrier(parallel)
-
-    top_calls = 0
 
     async def block(app: TestContext, a: int) -> int:
         nonlocal barrier
@@ -357,32 +343,19 @@ async def test_parallel(topic: str, task_name: str, use_gather: bool) -> None:
         gather = app.gather if use_gather else asyncio.gather
         await gather(*(app.call(block)(x) for x in range(parallel)))
 
-        # Mega hack workaround for our lack of parent debouncing, which causes
-        # this to be called multiple times, all of which goes through the queue
-        # we’re trying to close.  This if guard guarantees that the queue is
-        # only closed on the _last_ call to ‘top’, and we know no other message
-        # are put on the queue after this.  Of course the real solution is to
-        # debounce calls to the parent!
-        nonlocal top_calls
-        top_calls += 1
-        if top_calls == parallel:
-            await queue.close()
-
     async with brrr.serve(queue, store, store) as conn:
         app = AppWorker(
             handlers={name_top: top, name_block: block},
             codec=DemoPickleCodec(),
             connection=conn,
         )
-        # Don’t use queue.flush() because this test uses parallel workers
         await app.schedule(top, topic=topic)()
         await asyncio.gather(*(conn.loop(topic, app.handle) for _ in range(parallel)))
-        await queue.join()
 
 
 async def test_stress_parallel(topic: str, task_name: str) -> None:
     store = InMemoryByteStore()
-    queue = InMemoryQueue([topic])
+    queue = CloseOnSilenceQueue([topic])
 
     name_top, name_fib = names(task_name, ("top", "fib"))
 
@@ -411,16 +384,7 @@ async def test_stress_parallel(topic: str, task_name: str) -> None:
         )
         await app.schedule(top, topic=topic)()
 
-        # Terrible hack: because we don’t do proper parent debouncing, this stress
-        # test ends up with a metric ton of duplicate calls.
-        async def wait_and_close() -> None:
-            await asyncio.sleep(1)
-            await queue.close()
-
-        await asyncio.gather(
-            *([conn.loop(topic, app.handle) for _ in range(10)] + [wait_and_close()])
-        )
-        await queue.join()
+        await asyncio.gather(*(conn.loop(topic, app.handle) for _ in range(10)))
 
 
 async def test_debounce_child(topic: str, task_name: str) -> None:
@@ -462,7 +426,7 @@ async def test_no_debounce_parent(topic: str) -> None:
 
 async def test_app_loop_resumable(topic: str) -> None:
     store = InMemoryByteStore()
-    queue = InMemoryQueue([topic])
+    queue = CloseOnEmptyQueue([topic])
 
     errors = 5
 
@@ -474,7 +438,6 @@ async def test_app_loop_resumable(topic: str) -> None:
         if errors:
             errors -= 1
             raise MyError("retry")
-        await queue.close()
         return a
 
     async with brrr.serve(queue, store, store) as conn:
@@ -489,14 +452,12 @@ async def test_app_loop_resumable(topic: str) -> None:
             except MyError:
                 continue
 
-    await queue.join()
     assert errors == 0
 
 
 async def test_app_loop_resumable_nested(topic: str, task_name: str) -> None:
     store = InMemoryByteStore()
-    queue = InMemoryQueue([topic])
-    queue.flush()
+    queue = CloseOnEmptyQueue([topic])
 
     name_foo, name_bar = names(task_name, ("foo", "bar"))
 
@@ -529,7 +490,6 @@ async def test_app_loop_resumable_nested(topic: str, task_name: str) -> None:
             except MyError:
                 continue
 
-    await queue.join()
     assert errors == 0
 
 
@@ -558,7 +518,7 @@ async def test_app_handler_names(topic: str, task_name: str) -> None:
 
 async def test_app_subclass(topic: str) -> None:
     store = InMemoryByteStore()
-    queue = InMemoryQueue([topic])
+    queue = CloseOnEmptyQueue([topic])
 
     async def bar(app: TestContext, a: int) -> int:
         return a + 1
@@ -590,7 +550,6 @@ async def test_app_subclass(topic: str) -> None:
     async with brrr.serve(queue, store, store) as conn:
         app = MyAppWorker(handlers=handlers, codec=DemoPickleCodec(), connection=conn)
         await app.schedule(foo, topic=topic)(4)
-        queue.flush()
         await conn.loop(topic, app.handle)
         assert await app.read(foo)(4) == 14
 
@@ -600,7 +559,7 @@ async def test_custom_context(topic: str) -> None:
     Inject task name as a custom context.
     """
     store = InMemoryByteStore()
-    queue = InMemoryQueue([topic])
+    queue = CloseOnEmptyQueue([topic])
 
     class MyCodec(Codec[str]):
         def encode_call(
@@ -631,7 +590,6 @@ async def test_custom_context(topic: str) -> None:
         )
         await app.schedule(foo, topic=topic)()
         await app.schedule(bar, topic=topic)()
-        queue.flush()
         await conn.loop(topic, app.handle)
         assert await app.read(foo)() == "foo"
         assert await app.read(bar)() == "bar"

--- a/python/tests/test_connection.py
+++ b/python/tests/test_connection.py
@@ -1,7 +1,7 @@
 import brrr
 import pytest
 from brrr import Connection, Defer, DeferredCall, Request, Response
-from brrr.backends.in_memory import InMemoryByteStore, InMemoryQueue
+from brrr.backends.in_memory import CloseOnEmptyQueue, InMemoryByteStore
 from brrr.call import Call
 
 TOPIC = "brrr-test"
@@ -9,7 +9,7 @@ TOPIC = "brrr-test"
 
 async def test_conn_raw() -> None:
     store = InMemoryByteStore()
-    queue = InMemoryQueue([TOPIC])
+    queue = CloseOnEmptyQueue([TOPIC])
 
     async def handler(request: Request, conn: Connection) -> Defer | Response:
         call = request.call
@@ -39,7 +39,6 @@ async def test_conn_raw() -> None:
 
     async with brrr.serve(queue, store, store) as conn:
         await conn.schedule_raw(TOPIC, "hash1", "foo", b"123")
-        queue.flush()
         await conn.loop(TOPIC, handler)
         assert await conn.read_raw("hash1") == b"zim"
         assert await conn.read_raw("hash2") == b"inner return value"
@@ -48,7 +47,7 @@ async def test_conn_raw() -> None:
 
 async def test_conn_exception() -> None:
     store = InMemoryByteStore()
-    queue = InMemoryQueue([TOPIC])
+    queue = CloseOnEmptyQueue([TOPIC])
 
     count = 0
 
@@ -66,7 +65,6 @@ async def test_conn_exception() -> None:
     async with brrr.serve(queue, store, store) as conn:
         await conn.schedule_raw(TOPIC, "hash1", "foo", b"123")
         await conn.schedule_raw(TOPIC, "hash1", "foo", b"123")
-        queue.flush()
         with pytest.raises(MyError):
             await conn.loop(TOPIC, handler)
         assert await conn.read_raw("hash1") is None
@@ -77,8 +75,7 @@ async def test_conn_exception() -> None:
 
 async def test_conn_nop_closed_queue() -> None:
     store = InMemoryByteStore()
-    queue = InMemoryQueue([TOPIC])
-    await queue.close()
+    queue = CloseOnEmptyQueue([TOPIC])
 
     async def handler(request: Request, conn: Connection) -> Defer | Response:
         assert False

--- a/python/tests/test_in_memory_queue.py
+++ b/python/tests/test_in_memory_queue.py
@@ -1,18 +1,28 @@
-from collections.abc import Sequence
-from contextlib import asynccontextmanager
-from typing import AsyncIterator
+import asyncio
+import time
 
-from brrr.backends.in_memory import InMemoryQueue
-from brrr.queue import Queue
-
-from tests.contract_queue import QueueContract
+import pytest
+from brrr.backends.in_memory import CloseOnSilenceQueue
+from brrr.queue import QueueIsClosed
 
 
-class TestInMemoryQueue(QueueContract):
-    has_accurate_info = True
-
-    @asynccontextmanager
-    async def with_queue(self, topics: Sequence[str]) -> AsyncIterator[Queue]:
-        queue = InMemoryQueue(topics=topics)
-        queue.recv_block_secs = 1
-        yield queue
+async def test_close_on_silence() -> None:
+    q = CloseOnSilenceQueue(["t1", "t2"])
+    await q.put_message("t1", "foo")
+    await q.put_message("t2", "bar")
+    checkpoint = time.monotonic()
+    assert (await q.get_message("t1")).body == "foo"
+    with pytest.raises(QueueIsClosed):
+        await q.get_message("t1")
+    # This blocked for around a second:
+    assert 0.9 < time.monotonic() - checkpoint < 1.1
+    checkpoint = time.monotonic()
+    with pytest.raises(asyncio.QueueShutDown):
+        await q.put_message("t1", "frob")
+    with pytest.raises(asyncio.QueueShutDown):
+        await q.put_message("t2", "brap")
+    assert (await q.get_message("t2")).body == "bar"
+    with pytest.raises(QueueIsClosed):
+        await q.get_message("t2")
+    # None of that blocked
+    assert time.monotonic() - checkpoint < 0.1

--- a/python/tests/test_spawn_limit.py
+++ b/python/tests/test_spawn_limit.py
@@ -3,7 +3,7 @@ from collections import Counter
 import brrr
 import pytest
 from brrr import AppWorker, SpawnLimitError
-from brrr.backends.in_memory import InMemoryByteStore, InMemoryQueue
+from brrr.backends.in_memory import CloseOnEmptyQueue, InMemoryByteStore
 from brrr.demo_pickle_codec import DemoPickleCodec, DemoPickleCodecContext
 
 from .parametrize import names
@@ -12,7 +12,7 @@ type TestContext = DemoPickleCodecContext
 
 
 async def test_spawn_limit_depth(topic: str, task_name: str) -> None:
-    queue = InMemoryQueue([topic])
+    queue = CloseOnEmptyQueue([topic])
     store = InMemoryByteStore()
     n = 0
 
@@ -30,7 +30,6 @@ async def test_spawn_limit_depth(topic: str, task_name: str) -> None:
             handlers={task_name: foo}, codec=DemoPickleCodec(), connection=conn
         )
         await app.schedule(task_name, topic=topic)(conn._spawn_limit + 3)
-        queue.flush()
 
         with pytest.raises(SpawnLimitError):
             await conn.loop(topic, app.handle)
@@ -39,7 +38,7 @@ async def test_spawn_limit_depth(topic: str, task_name: str) -> None:
 
 
 async def test_spawn_limit_breadth_mapped(topic: str, task_name: str) -> None:
-    queue = InMemoryQueue([topic])
+    queue = CloseOnEmptyQueue([topic])
     store = InMemoryByteStore()
     calls = Counter[str]()
     name_one, name_foo = names(task_name, ("one", "foo"))
@@ -61,7 +60,6 @@ async def test_spawn_limit_breadth_mapped(topic: str, task_name: str) -> None:
             connection=conn,
         )
         await app.schedule(name_foo, topic=topic)(conn._spawn_limit + 4)
-        queue.flush()
 
         with pytest.raises(SpawnLimitError):
             await conn.loop(topic, app.handle)
@@ -70,7 +68,7 @@ async def test_spawn_limit_breadth_mapped(topic: str, task_name: str) -> None:
 
 
 async def test_spawn_limit_recoverable(topic: str, task_name: str) -> None:
-    queue = InMemoryQueue([topic])
+    queue = CloseOnEmptyQueue([topic])
     store = InMemoryByteStore()
     cache = InMemoryByteStore()
     name_one, name_foo = names(task_name, ("one", "foo"))
@@ -97,7 +95,6 @@ async def test_spawn_limit_recoverable(topic: str, task_name: str) -> None:
             cache.inner = {}
             try:
                 await app.schedule(name_foo, topic=topic)(n)
-                queue.flush()
                 await conn.loop(topic, app.handle)
                 break
             except SpawnLimitError:
@@ -109,7 +106,7 @@ async def test_spawn_limit_recoverable(topic: str, task_name: str) -> None:
 
 
 async def test_spawn_limit_breadth_manual(topic: str, task_name: str) -> None:
-    queue = InMemoryQueue([topic])
+    queue = CloseOnEmptyQueue([topic])
     store = InMemoryByteStore()
     calls = Counter[str]()
     name_one, name_foo = names(task_name, ("one", "foo"))
@@ -135,7 +132,6 @@ async def test_spawn_limit_breadth_manual(topic: str, task_name: str) -> None:
             connection=conn,
         )
         await app.schedule(name_foo, topic=topic)(conn._spawn_limit + 3)
-        queue.flush()
         with pytest.raises(SpawnLimitError):
             await conn.loop(topic, app.handle)
 
@@ -145,7 +141,7 @@ async def test_spawn_limit_breadth_manual(topic: str, task_name: str) -> None:
 
 
 async def test_spawn_limit_cached(topic: str, task_name: str) -> None:
-    queue = InMemoryQueue([topic])
+    queue = CloseOnEmptyQueue([topic])
     store = InMemoryByteStore()
     name_foo, name_same = names(task_name, ("foo", "same"))
     n = 0
@@ -170,7 +166,6 @@ async def test_spawn_limit_cached(topic: str, task_name: str) -> None:
             connection=conn,
         )
         await app.schedule(name_foo, topic=topic)(conn._spawn_limit + 5)
-        queue.flush()
         await conn.loop(topic, app.handle)
 
         assert n == 1


### PR DESCRIPTION
painful for parallel tests which are now much slower, but should fix the race condition.

Even if there was technically no bug, I would prefer this, because it's so much simpler. The previous solution was too convoluted, and if correct, would only be accidentally so.