### PR TITLE
feat(docsync): docsync-get: CLI to get docsyncs

### DIFF
--- a/docsync/package.json
+++ b/docsync/package.json
@@ -9,7 +9,8 @@
     "test": "tsc"
   },
   "bin": {
-    "docsync-check": "src/docsync-check.ts"
+    "docsync-check": "src/docsync-check.ts",
+    "docsync-get": "src/docsync-get.ts"
   },
   "keywords": [],
   "author": "",

--- a/docsync/package.nix
+++ b/docsync/package.nix
@@ -1,5 +1,7 @@
 {
+  diffutils,
   gnused,
+  jq,
   lib,
   package-lock2nix,
   runCommand,
@@ -8,6 +10,27 @@
 let
   final = package-lock2nix.mkNpmModule {
     src = ./.;
+    doInstallCheck = true;
+    nativeBuildInputs = [
+      diffutils
+      jq
+    ];
+    installCheckPhase =
+      let
+        fixtures = {
+          CmdCheck = "docsync-check checks if two directories' doc tags are in sync.";
+          CmdGet = "docsync-get extracts all docsync nodes under a path.";
+        };
+        fixture = builtins.toFile "fixture" (builtins.toJSON fixtures);
+      in
+      ''
+        f="$(mktemp)"
+        $out/bin/docsync-get ${./src} > $f
+        diff -u <(jq --sort-keys . ${fixture}) <(jq --sort-keys . $f)
+        $out/bin/docsync-get ${./src} CmdGet > $f
+        diff -u ${builtins.toFile "test" (fixtures.CmdGet + "\n")} $f
+        ! $out/bin/docsync-get ${./src} NonExistentKey
+      '';
     passthru.tests.docsync = runCommand "docsync" { nativeBuildInputs = [ final ]; } ''
       docsync-check ${../python/src} ${../typescript/src}
       touch $out

--- a/docsync/package.nix
+++ b/docsync/package.nix
@@ -24,12 +24,14 @@ let
         fixture = builtins.toFile "fixture" (builtins.toJSON fixtures);
       in
       ''
-        f="$(mktemp)"
-        $out/bin/docsync-get ${./src} > $f
-        diff -u <(jq --sort-keys . ${fixture}) <(jq --sort-keys . $f)
-        $out/bin/docsync-get ${./src} CmdGet > $f
-        diff -u ${builtins.toFile "test" (fixtures.CmdGet + "\n")} $f
-        ! $out/bin/docsync-get ${./src} NonExistentKey
+        $out/bin/docsync-get ${./src} > full-out
+        diff -u <(jq --sort-keys . ${fixture}) <(jq --sort-keys . full-out)
+
+        $out/bin/docsync-get ${./src} CmdGet > single-out
+        diff -u ${builtins.toFile "test" (fixtures.CmdGet + "\n")} single-out
+
+        ! $out/bin/docsync-get ${./src} KeyWhichDoesntExistForTestingSake
+        ! $out/bin/docsync-get ${./src} CmdGet extra-arg
       '';
     passthru.tests.docsync = runCommand "docsync" { nativeBuildInputs = [ final ]; } ''
       docsync-check ${../python/src} ${../typescript/src}

--- a/docsync/src/cmds.ts
+++ b/docsync/src/cmds.ts
@@ -28,3 +28,15 @@ E.g.:
 
   deepStrictEqual(a, b);
 }
+
+export async function docsyncGet(): Promise<void> {
+  const path = process.argv[2];
+  if (!path) {
+    console.error("Usage: docsync-get <PATH>");
+    process.exit(1);
+  }
+
+  const parser = new PathParser();
+  const o = Object.fromEntries((await parser.getPath(path)).entries());
+  console.log(JSON.stringify(o));
+}

--- a/docsync/src/cmds.ts
+++ b/docsync/src/cmds.ts
@@ -4,6 +4,11 @@ import process from "node:process";
 
 import { PathParser } from "./path-parser.ts";
 
+/**
+ * docsync-check checks if two directories' doc tags are in sync.
+ *
+ * <docsync>CmdCheck</docsync>
+ */
 export async function docsyncCheck(): Promise<void> {
   const [dirA, dirB] = process.argv.slice(2);
   if (!dirA || !dirB) {
@@ -29,14 +34,41 @@ E.g.:
   deepStrictEqual(a, b);
 }
 
+/**
+ * docsync-get extracts all docsync nodes under a path.
+ *
+ * <docsync>CmdGet</docsync>
+ */
 export async function docsyncGet(): Promise<void> {
-  const path = process.argv[2];
+  const [path, slug] = process.argv.slice(2);
   if (!path) {
-    console.error("Usage: docsync-get <PATH>");
+    console.error(`
+Usage: docsync-get <PATH> [SLUG]
+
+Example:
+
+    $ docsync-get ./src/cmds.ts | jq
+    {
+      "CmdCheck": "docsync-check checks if two directories' doc tags are in sync.",
+      "CmdGet": "docsync-get extracts all docsync nodes under a path."
+    }
+
+    $ docsync-get ./src/cmds.ts CmdGet
+    docsync-get extracts all docsync nodes under a path.
+`);
     process.exit(1);
   }
 
   const parser = new PathParser();
-  const o = Object.fromEntries((await parser.getPath(path)).entries());
-  console.log(JSON.stringify(o));
+  const m = await parser.getPath(path);
+  if (slug !== undefined) {
+    if (!m.has(slug)) {
+      console.error(`No such key ${slug} in docsync tags for ${path}`);
+      process.exit(1);
+    }
+    console.log(m.get(slug));
+  } else {
+    const o = Object.fromEntries(m.entries());
+    console.log(JSON.stringify(o));
+  }
 }

--- a/docsync/src/cmds.ts
+++ b/docsync/src/cmds.ts
@@ -40,21 +40,21 @@ E.g.:
  * <docsync>CmdGet</docsync>
  */
 export async function docsyncGet(): Promise<void> {
-  const [path, slug] = process.argv.slice(2);
-  if (!path) {
+  const [path, slug, ...extra] = process.argv.slice(2);
+  if (!path || extra.length > 0) {
     console.error(`
 Usage: docsync-get <PATH> [SLUG]
 
 Example:
 
-    $ docsync-get ./src/cmds.ts | jq
+    $ docsync-get ./some/example.ts | jq
     {
-      "CmdCheck": "docsync-check checks if two directories' doc tags are in sync.",
-      "CmdGet": "docsync-get extracts all docsync nodes under a path."
+      "Foo": "Foo class with its foo docstring",
+      "Bar": "The Bar class also has an important docstring"
     }
 
-    $ docsync-get ./src/cmds.ts CmdGet
-    docsync-get extracts all docsync nodes under a path.
+    $ docsync-get ./some/example.ts Foo
+    Foo class with its docstring
 `);
     process.exit(1);
   }
@@ -63,7 +63,7 @@ Example:
   const m = await parser.getPath(path);
   if (slug !== undefined) {
     if (!m.has(slug)) {
-      console.error(`No such key ${slug} in docsync tags for ${path}`);
+      console.error(`No such key ${slug} in docsync tags for ${path}.`);
       process.exit(1);
     }
     console.log(m.get(slug));

--- a/docsync/src/docsync-get.ts
+++ b/docsync/src/docsync-get.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node --enable-source-maps
+
+import { docsyncGet } from "./cmds.ts";
+
+await docsyncGet();


### PR DESCRIPTION
Example:

```command
$ docsync-get typescript/src | jq
{
  "Call": "A full brrr request payload. This is a low-level brrr primitive. The memo key must be generated by the instantiator of this class, and it must be deterministic: the \"same\" args and kwargs must always encode to the same memo key. Using the same memo key, we store the task and its argv here so we can retrieve them in workers.",
  "PendingReturns": "Set of parents waiting for a child call to complete. When the child call is scheduled, a timestamp is added to this record to indicate it doesn't need to be rescheduled. If the record exists but with a null scheduled timestamp, you cannot be sure this child has ever actually been scheduled, so it should be rescheduled. This record is used in highly race sensitive context and is the point of a lot of CASing."
}
```