### PR TITLE
fix(ts): don't redeliver handled pending returns on CAS retry

### DIFF
--- a/typescript/src/store.test.ts
+++ b/typescript/src/store.test.ts
@@ -282,6 +282,43 @@ await suite(import.meta.filename, async () => {
         strictEqual(mockFn.mock.callCount(), 1);
         strictEqual(await store.get(fixture.pendingReturns.key), undefined);
       });
+
+      await test("delivers each return to f exactly once across CAS retries", async () => {
+        const initialReturns = [
+          new PendingReturn("a", "b", "c"),
+          new PendingReturn("d", "e", "f"),
+        ];
+        const concurrentReturn = new PendingReturn("g", "h", "i");
+        await store.set(
+          fixture.pendingReturns.key,
+          new PendingReturns(undefined, initialReturns).encode(),
+        );
+        const delivered: string[] = [];
+        await memory.withPendingReturnsRemove(
+          fixture.pendingReturns.key.callHash,
+          async (returns) => {
+            const isFirstInvocation = delivered.length === 0;
+            delivered.push(
+              ...[...returns].map((it) => TaggedTuple.encodeToString(it)),
+            );
+            if (isFirstInvocation) {
+              // Race a concurrent addPendingReturns between the get and the
+              // compareAndDelete to force a CAS retry.
+              await memory.addPendingReturns(
+                fixture.pendingReturns.key.callHash,
+                concurrentReturn,
+              );
+            }
+          },
+        );
+        deepStrictEqual(
+          [...delivered].sort(),
+          [...initialReturns, concurrentReturn]
+            .map((it) => TaggedTuple.encodeToString(it))
+            .sort(),
+        );
+        strictEqual(await store.get(fixture.pendingReturns.key), undefined);
+      });
     });
   });
 });

--- a/typescript/src/store.ts
+++ b/typescript/src/store.ts
@@ -238,20 +238,23 @@ export class Memory {
       type: "pending_returns",
       callHash,
     };
-    const handled = new Set<PendingReturn>();
+    const handled = new Set<string>();
     return this.withCas(async () => {
       const pendingEncoded = await this.store.get(memKey);
       if (!pendingEncoded) {
         return true;
       }
+      const toHandleEncoded =
+        PendingReturns.decode(pendingEncoded).encodedReturns.difference(
+          handled,
+        );
       const toHandle = new Set(
-        PendingReturns.decode(pendingEncoded)
-          .encodedReturns.difference(handled)
+        toHandleEncoded
           .values()
           .map((it) => TaggedTuple.decodeFromString(PendingReturn, it)),
       );
       await f(toHandle);
-      for (const it of toHandle) {
+      for (const it of toHandleEncoded) {
         handled.add(it);
       }
       return this.store.compareAndDelete(memKey, pendingEncoded);


### PR DESCRIPTION
Fixes #242.

`handled` now lives in the encoded-string domain (value equality), mirroring the Python implementation's frozen-dataclass set semantics (`store.py:344-362`). The difference is computed on encoded returns before decoding, so CAS retries only deliver returns not yet handed to the callback.

Regression test: seeds returns, forces a CAS retry via a concurrent `addPendingReturns` on the callback's first invocation, asserts each return is delivered to `f` exactly once and the record is deleted. It fails on master with the duplicate-delivery output quoted in #242.

`npm test`: 136 pass / 0 fail. `tsc --noEmit` and prettier clean. No Python changes.
